### PR TITLE
feat: support integer (not quoted) key

### DIFF
--- a/src/jsone.erl
+++ b/src/jsone.erl
@@ -248,6 +248,7 @@
                          reject_invalid_utf8 |
                          {'keys', 'binary' | 'atom' | 'existing_atom' | 'attempt_atom'} |
                          {duplicate_map_keys, first | last} |
+                         {allow_int_key, boolean()} |
                          common_option().
 %% `object_format': <br />
 %% - Decoded JSON object format <br />
@@ -288,6 +289,8 @@
 %% - If the value is `last' then the last duplicate key/value is returned.
 %% - default: `first'<br />
 %%
+%% `allow_int_key': <br />
+%% Allows single-byte integer as key.
 
 -type stack_item() :: {Module :: module(),
                        Function :: atom(),

--- a/test/jsone_decode_tests.erl
+++ b/test/jsone_decode_tests.erl
@@ -286,3 +286,14 @@ decode_test_() ->
               ?assertMatch({ok, _, _}, jsone:try_decode(Input)),
               ?assertMatch({error, {badarg, _}}, jsone:try_decode(Input, [reject_invalid_utf8]))
       end}].
+
+int_key_test() ->
+    Dec = fun(Input) -> jsone:decode(iolist_to_binary(Input), [{allow_int_key, true}]) end,
+    ?assertEqual(#{<<"0">> => <<"a">>}, Dec("{0: \"a\"}")),
+    ?assertEqual(#{<<"0">> => <<"a">>}, Dec("{\"0\": \"a\"}")),
+    ?assertEqual(#{<<"10">> => 100}, Dec("{10 : 100}")),
+    ?assertEqual(#{<<"10">> => 100}, Dec("{\"10\" : 100}")),
+    ?assertEqual(#{<<"1">> => #{<<"10">> => 100}}, Dec("{1: {10 : 100}}")),
+    ?assertError(badarg, Dec("{12. : x}")),
+    ?assertError(badarg, Dec("{whatever : 1}")),
+    ok.


### PR DESCRIPTION
This is to make jsone work with rocketmq 4.9.3 or older.

The issue is already fixed in RocktMQ 4.9.4 according to [this PR](https://github.com/apache/rocketmq/pull/4432)
But we have to keep supporting the older versions.


an example input:
```
<<"{\"brokerDatas\":[{\"brokerAddrs\":{0:\"192.168.1.204:10911\",1:\"192.168.1.198:11911\"},\"brokerName\":\"broker-b\",\"cluster\":\"DefaultCluster\"}],\"filterServerTable\":{},\"queueDatas\":[{\"brokerName\":\"broker-b\",\"perm\":6,\"readQueueNums\":8,\"topicSynFlag\":0,\"writeQueueNums\":8}]}">>
```
With the new feature, `jsone:decode(Input, [{allow_int_key, true}]).` returns

```
#{<<"brokerDatas">> =>
      [#{<<"brokerAddrs">> =>
             #{<<"0">> => <<"192.168.1.204:10911">>,
               <<"1">> => <<"192.168.1.198:11911">>},
         <<"brokerName">> => <<"broker-b">>,
         <<"cluster">> => <<"DefaultCluster">>}],
  <<"filterServerTable">> => #{},
  <<"queueDatas">> =>
      [#{<<"brokerName">> => <<"broker-b">>,<<"perm">> => 6,
         <<"readQueueNums">> => 8,<<"topicSynFlag">> => 0,
         <<"writeQueueNums">> => 8}]}
```